### PR TITLE
Expose failure cause in context

### DIFF
--- a/interactor.gemspec
+++ b/interactor.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Simple interactor implementation"
   spec.homepage = "https://github.com/sorare/interactor"
   spec.license = "MIT"
+  spec.required_ruby_version = '>= 2.1'
 
   spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files = spec.files.grep(/^spec/)

--- a/lib/interactor.rb
+++ b/lib/interactor.rb
@@ -145,7 +145,7 @@ module Interactor
     end
   rescue Failure => e
     # Make sure we fail the current context when a call! to another interactor fails
-    context.fail!(error: e.context&.error)
+    context.fail!(error: e.context&.error, error_cause: e.cause)
   end
 
   # Public: Invoke an Interactor instance without any hooks, tracking, or

--- a/lib/interactor/context.rb
+++ b/lib/interactor/context.rb
@@ -58,7 +58,7 @@ module Interactor
       end
     end
 
-    attr_accessor :error
+    attr_accessor :error, :error_cause
     delegate :to_s, to: :to_h
 
     # Public: Whether the Interactor::Context is successful. By default, a new

--- a/spec/interactor_spec.rb
+++ b/spec/interactor_spec.rb
@@ -63,6 +63,8 @@ describe Interactor do
 
   describe "#run" do
     let(:instance) { interactor.new }
+    let(:exception_klass) { Class.new(Exception) }
+    let(:failure_cause) { exception_klass.new }
 
     it "runs the interactor" do
       expect(instance).to receive(:run!).once.with(no_args)
@@ -76,6 +78,15 @@ describe Interactor do
       expect {
         instance.run
       }.not_to raise_error
+    end
+
+    it "persists failure cause" do
+      expect(instance).to receive(:call).and_raise(
+        Interactor::Failure.new(instance.context), cause: failure_cause
+      )
+
+      instance.run
+      expect(instance.context.error_cause).to eq(failure_cause)
     end
 
     it "raises other errors" do


### PR DESCRIPTION
When called without raising, the [exception cause](https://ruby-doc.org/core-2.1.0/Exception.html#method-i-cause) is lost. This proposal exposes the cause.

This would drop support for Ruby version < 2.1